### PR TITLE
Change Kennytv's reason + add My Project + Add MagmaMC for modifing EssentialsX Bytecode&abusing Log4j, and add Spongeforge as a alternative of Bukkit+Forge Hybrid

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,9 @@ A non-exhaustive list of dank projects.
 * [Yatopia](https://github.com/YatopiaMC/Yatopia), [Mirai](https://github.com/etil2jz/Mirai) - *[Ouch](https://github.com/kennytv/Yaptapia)*.
 * Hybrid Servers (Forge/Something else + Bukkit) - Servers that combine
   two incompatible APIs and break them both in the process.
+    * [MagmaMC](https://github.com/MagmaFoundation/Magma) - Brake EssentialsX Code([See The Warning](https://essentialsx.net/downloads.html)) and also [Abused log4j bug](https://pixelmonmod.com/viewtopic.php?f=5&t=29799&p=210147)
     * [CatServer](https://github.com/Luohuayu/CatServer) - [Breaking license restrictions](https://github.com/Luohuayu/FoxServer/issues/7#issuecomment-1100009357).
-    * [Mohist](https://github.com/MohistMC/Mohist) - [Swapped Essentials' plugin jar](https://github.com/MohistMC/Mohist/blob/70a303f4d02e9480cc5472c1c26f7d9cb6560732/src/fmllauncher/java/com/mohistmc/AutoDeletePlugins.java#L20-L22)
-      after trying to [submit a PR](https://github.com/EssentialsX/Essentials/pull/3580) to Essentials to fix their own
-      end of the Bukkit API. *Then* tried to turn [Essentials' PSA](https://essentialsx.net/do-not-use-mohist.html)
-      regarding security concerns [into an ad](https://github.com/EssentialsX/Website/pull/44).
+     * [NogyangForge](https://github.com/GAME-CLI-SRV-DEV/NogyangForge) - added Geyser-Neoforge 2.3.0 Support + Floodgate-Core 2.2.3 and Ultimately Modified Bukkit API to Support Mods Properly. it count as Same Reason with purpur! 
 * [PolyMC](https://github.com/PolyMC/PolyMC) - Common sense and decency? [Never heard of her](https://github.com/PolyMC/PolyMC/commit/ccf282593dcdbe189c99b81b8bc90cb203aed3ee).
 * [Songoda](https://songoda.com/marketplace) - We still tell tales of one of the most sketchy plugin marketplaces.
 * [Yooniks](https://www.mc-market.org/members/126711/) - If you feel like you have too much money and you are looking
@@ -41,10 +39,11 @@ A non-exhaustive list of dank projects.
   with [pm2 Process Manager](https://pm2.io/)).
 * [SunLight](https://www.spigotmc.org/resources/sunlight.67733/) - Taking RGB chat formatting to another level, parsing hex codes in
   *other plugins'* commands with the only way around that being
-  to [use their library to convert them back](https://www.spigotmc.org/threads/sunlight.374716/page-39#post-4124177).
+  to [use their library to convert them back](https://www.spigotmc.org/threads/sunlight.374716/page-39#post-4124177). (bro just use MiniMessage)
 * [ProVotes](https://www.spigotmc.org/resources/provotes.23672/) - Premium in
   the [least premium way possible](https://github.com/kennytv/list-of-shame/issues/77).
-* Purpur - What if someone made a fork instead of just creating plugins doing the same things?
+* [Purpur](https://github.com/PurpurMC/Purpur) - What if someone made a fork instead of just creating plugins doing the same things?
+* [NogyangSpigot](https://github.com/GAME-CLI-SRV-DEV/NogyangSpigot) - Same Reason With Purpur.
 * [ClearLagg](https://www.spigotmc.org/resources/clearlagg.68271/) - Causes more lag than it removes and doesn't even know its own name.
 * [gitmoji](https://github.com/carloscuesta/gitmoji) - Using emojis on commit messages provides an easy way of
   identifying the purpose or intention of a commit with only looking at the emojis used... as long as you can learn
@@ -63,7 +62,7 @@ A non-exhaustive list of dank projects.
 * [Retrooper, again](https://github.com/kennytv/list-of-shame/pull/67)
 * [The Duper Trooper](https://www.youtube.com/channel/UC_Nuc3040H1WjeO9aoY4NPg) - Clickbait YouTube channel that "leaks"
   often outdated exploits and encourages bad habits around security issues.
-* [kennytv](https://www.twitch.tv/kennytvn) - German streamer who has repeatedly failed to meet streaming obligations
+* [kennytv](https://www.twitch.tv/kennytvn) - German streamer who has repeatedly failed to meet streaming obligations, and works on [ViaVersion](https://github.com/ViaVersion/ViaVersion), which Continuously Allows "Evil" to Exist.
 * [alexisl315](https://www.spigotmc.org/members/190298/) - Your go-to dev for so bad it's funny Skript recreations of
   popular plugins.
 
@@ -74,7 +73,7 @@ This section is the only part of this page you should *actually* take somewhat s
 * "Super optimized all-in-one server" alternatives: The most performant AND properly stable will likely always be Paper.
     * Info: <https://github.com/kennytv/Yaptapia> (not necessarily bound to Yatopia)
 * "Hybrid" (Forge/something else + Bukkit) server
-  info/alternatives: [Essentials' PSA](https://essentialsx.net/do-not-use-mohist.html).
+  info/alternatives: Info: [Essentials' PSA](https://essentialsx.net/do-not-use-mohist.html), [Essentials' Downloads](https://essentialsx.net/downloads), Alternative: [SpongeForge](www.Spongepowered.com).
 * Anti-lag plugin alternative setup and info: <https://www.spigotmc.org/threads/283181/>
   and <https://www.spigotmc.org/threads/283181/page-20#post-3684550>
 * Dupe fixer alternative: Simply use Paper (not one of the cursed forks as mentioned above) and stay on the latest version of Minecraft

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ https://kennytv.github.io/list-of-shame
 
 A non-exhaustive list of dank projects.
 
+* Democratic Federal Republic Of Craftbukkit and SpongeVanilla - Oh No They Formed the Micronation to conquer the world, we are all gonna die by Plugin/Ore Nukes
+* Outfit8TSB - The Lead Dev of NBM(Become BM) and Radioactive
 * [#saveminecraft](https://youtu.be/wXQoH4IQGMM)
 * 1.8 - Has more exploits and security issues than [days it is old](https://howoldisminecraft188.today/).
 * 1.7 - Like 1.8 but worse and [even older](https://howoldisminecraft1710.today/).
@@ -16,16 +18,20 @@ A non-exhaustive list of dank projects.
 * [StellarDev](https://stellardev.org/), Aside from the usual closed-source Spigot
   forks, get paid to steal code without
   attribution, [bar a little slip up...](https://github.com/NFT-Worlds/Server/blob/4f7bc3329aadac0667b8bb8d6d384558566af6ff/patches/server/0046-Async-Entities.patch#L238)<!-- Even more ironic if you look at who this was made for -->
-* [Yatopia](https://github.com/YatopiaMC/Yatopia), [Mirai](https://github.com/etil2jz/Mirai) - *[Ouch](https://github.com/kennytv/Yaptapia)*.
-* Hybrid Servers (Forge/Something else + Bukkit) - Servers that combine
+* Ohioan Server Softwares that goes to Ohio way
+  * [Yatopia](https://github.com/YatopiaMC/Yatopia), [Mirai](https://github.com/etil2jz/Mirai) - *[Ouch](https://github.com/kennytv/Yaptapia)*.
+  * [Purformance](https://github.com/YatopiaMC/Yatopia) - the most Ohioan Server Software Ever Born, it is unholy. it's worse than Normal.
+  * [Radioactive](https://github.com/GAME-CLI-SRV-DEV/Radioactive.git) - You Can't Combine more Implementations, You are going to be fat like Yatopia. Wait, did the dev just formed a country try to boycott Convention Of International Endangered Species Of Wild Fauna and Flora Of Washington District Of Columbia By Combining all of Bukkit? Did They Use Towny or Nations to govern it? Well, Too bad! GO Outside To Protest about CITES. CITES Will Not Listen and Fubao will not return to korea. That's the Law, Deal With It and shut up. womp womp :skull:
+ * Hybrid Servers (Forge/Something else + Bukkit) - Servers that combine
   two incompatible APIs and break them both in the process.
-    * [MagmaMC](https://github.com/MagmaFoundation/Magma) - Brake EssentialsX Code([See The Warning](https://essentialsx.net/downloads.html)) and also [Abused log4j bug](https://pixelmonmod.com/viewtopic.php?f=5&t=29799&p=210147)
+    * [Magma Foundation](https://github.com/MagmaFoundation/Magma) - Brake EssentialsX Code([See The Warning](https://essentialsx.net/downloads.html)) and also [Abused log4j bug](https://pixelmonmod.com/viewtopic.php?f=5&t=29799&p=210147)
     * [CatServer](https://github.com/Luohuayu/CatServer) - [Breaking license restrictions](https://github.com/Luohuayu/FoxServer/issues/7#issuecomment-1100009357).
      * [NogyangForge](https://github.com/GAME-CLI-SRV-DEV/NogyangForge) - added Geyser-Neoforge 2.3.0 Support + Floodgate-Core 2.2.3 and Ultimately Modified Bukkit API to Support Mods Properly. but still, it count as Same Reason with purpur. 
 * [PolyMC](https://github.com/PolyMC/PolyMC) - Common sense and decency? [Never heard of her](https://github.com/PolyMC/PolyMC/commit/ccf282593dcdbe189c99b81b8bc90cb203aed3ee).
 * [Songoda](https://songoda.com/marketplace) - We still tell tales of one of the most sketchy plugin marketplaces.
 * [Yooniks](https://www.mc-market.org/members/126711/) - If you feel like you have too much money and you are looking
   for closed-source forks of Bungee/Spigot, look no further.
+* BadBird5907 - You Cant Just Go to random pull requests to get a free taco, if you want taco then go buy with your money at your local shop.
 * [Kangarko](https://github.com/kangarko) - Advertising genius behind paid plugin-courses.
     - Latest victim of his blame: [All of SpigotMC](https://www.spigotmc.org/threads/478408/)
 * [EpicWorldGenerator](https://www.spigotmc.org/resources/epicworldgenerator.8067/) - Because it sure is worth spending
@@ -65,7 +71,7 @@ A non-exhaustive list of dank projects.
 * [kennytv](https://www.twitch.tv/kennytvn) - German streamer who has repeatedly failed to meet streaming obligations, and works on [ViaVersion](https://github.com/ViaVersion/ViaVersion), which Continuously Allows "Evil" to Exist.
 * [alexisl315](https://www.spigotmc.org/members/190298/) - Your go-to dev for so bad it's funny Skript recreations of
   popular plugins.
-* [SpottedLeaf](https://github.com/spottedleaf)- resolved [this](https://github.com/kennytv/list-of-shame/issues/46) by [this](https://github.com/kennytv/list-of-shame/commit/8f636460d99dfb5d299326b015b491c04c009e7c)
+* [SpottedLeaf](https://github.com/spottedleaf) - resolved [this](https://github.com/kennytv/list-of-shame/issues/46) by [this](https://github.com/kennytv/list-of-shame/commit/8f636460d99dfb5d299326b015b491c04c009e7c)
 
 ## Software Alternatives / Info Threads
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ A non-exhaustive list of dank projects.
 * [kennytv](https://www.twitch.tv/kennytvn) - German streamer who has repeatedly failed to meet streaming obligations, and works on [ViaVersion](https://github.com/ViaVersion/ViaVersion), which Continuously Allows "Evil" to Exist.
 * [alexisl315](https://www.spigotmc.org/members/190298/) - Your go-to dev for so bad it's funny Skript recreations of
   popular plugins.
+[SpottedLeaf](https://github.com/spottedleaf)- https://github.com/kennytv/list-of-shame/commit/8f636460d99dfb5d299326b015b491c04c009e7c
 
 ## Software Alternatives / Info Threads
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ A non-exhaustive list of dank projects.
 * [kennytv](https://www.twitch.tv/kennytvn) - German streamer who has repeatedly failed to meet streaming obligations, and works on [ViaVersion](https://github.com/ViaVersion/ViaVersion), which Continuously Allows "Evil" to Exist.
 * [alexisl315](https://www.spigotmc.org/members/190298/) - Your go-to dev for so bad it's funny Skript recreations of
   popular plugins.
-[SpottedLeaf](https://github.com/spottedleaf)- https://github.com/kennytv/list-of-shame/commit/8f636460d99dfb5d299326b015b491c04c009e7c
+* [SpottedLeaf](https://github.com/spottedleaf)- resolved [this](https://github.com/kennytv/list-of-shame/issues/46) by [this](https://github.com/kennytv/list-of-shame/commit/8f636460d99dfb5d299326b015b491c04c009e7c)
 
 ## Software Alternatives / Info Threads
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A non-exhaustive list of dank projects.
   two incompatible APIs and break them both in the process.
     * [MagmaMC](https://github.com/MagmaFoundation/Magma) - Brake EssentialsX Code([See The Warning](https://essentialsx.net/downloads.html)) and also [Abused log4j bug](https://pixelmonmod.com/viewtopic.php?f=5&t=29799&p=210147)
     * [CatServer](https://github.com/Luohuayu/CatServer) - [Breaking license restrictions](https://github.com/Luohuayu/FoxServer/issues/7#issuecomment-1100009357).
-     * [NogyangForge](https://github.com/GAME-CLI-SRV-DEV/NogyangForge) - added Geyser-Neoforge 2.3.0 Support + Floodgate-Core 2.2.3 and Ultimately Modified Bukkit API to Support Mods Properly. it count as Same Reason with purpur! 
+     * [NogyangForge](https://github.com/GAME-CLI-SRV-DEV/NogyangForge) - added Geyser-Neoforge 2.3.0 Support + Floodgate-Core 2.2.3 and Ultimately Modified Bukkit API to Support Mods Properly. but still, it count as Same Reason with purpur. 
 * [PolyMC](https://github.com/PolyMC/PolyMC) - Common sense and decency? [Never heard of her](https://github.com/PolyMC/PolyMC/commit/ccf282593dcdbe189c99b81b8bc90cb203aed3ee).
 * [Songoda](https://songoda.com/marketplace) - We still tell tales of one of the most sketchy plugin marketplaces.
 * [Yooniks](https://www.mc-market.org/members/126711/) - If you feel like you have too much money and you are looking

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This section is the only part of this page you should *actually* take somewhat s
 * "Super optimized all-in-one server" alternatives: The most performant AND properly stable will likely always be Paper.
     * Info: <https://github.com/kennytv/Yaptapia> (not necessarily bound to Yatopia)
 * "Hybrid" (Forge/something else + Bukkit) server
-  info/alternatives: Info: [Essentials' PSA](https://essentialsx.net/do-not-use-mohist.html), [Essentials' Downloads](https://essentialsx.net/downloads), Alternative: [SpongeForge](www.Spongepowered.com).
+  info/alternatives: Info: [Essentials' PSA](https://essentialsx.net/do-not-use-mohist.html), [Essentials' Downloads](https://essentialsx.net/downloads), Alternative: [SpongeForge](https://www.Spongepowered.org).
 * Anti-lag plugin alternative setup and info: <https://www.spigotmc.org/threads/283181/>
   and <https://www.spigotmc.org/threads/283181/page-20#post-3684550>
 * Dupe fixer alternative: Simply use Paper (not one of the cursed forks as mentioned above) and stay on the latest version of Minecraft


### PR DESCRIPTION
Proof:
🔭 I mainly work on Paper, ViaVersion <-- , and Hangar. - from kennytv/readme.md
![Screenshot_20240624-104413](https://github.com/kennytv/list-of-shame/assets/167604853/9d9250ee-eab1-4eaa-a8fd-3f42aa9b39a5)
You Work on ViaVersion means you working on one of dank project called viaversion.
to that continously let evil to live.
3 of My Projects are using GeyserMC Because i only have is Bedrock Edition. i should've created bukkit plugins instead.
(note: i forgot to add spottedleaf for adding kennytv,indirectly merging one of retrooper's pr. so this pull request is draft until spottedleaf is added.)
if this pr won't merge, add me in this list of shame instead, because,
i mashed 2 server softwares, which is PlazmaMC and LeavesMC, in one server software to boycott International Organization.
i also created pull request that dosen't make any sense to turn into a dictator of server software.(eventhough one of responder how to port pufferfish properly without turning my project into dank project, but it turns out it transformed into dank project)
i am also turned into dictator of server software by creating MultiNet(Minestom) and NogyangSpigot(NMS)